### PR TITLE
Feature fix bug characters

### DIFF
--- a/src/app/word-frequency-analyzer/word-frequency-analyzer.component.spec.ts
+++ b/src/app/word-frequency-analyzer/word-frequency-analyzer.component.spec.ts
@@ -19,9 +19,9 @@ describe('WordFrequencyAnalyzerComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(WordFrequencyAnalyzerComponent);
     component = fixture.componentInstance;
-    component.text = 'The sun shines over the lake.'
+    component.text = 'The sun shines over the lake.';
     component.n = 3;
-    component.word = 'the'
+    component.word = 'the';
     fixture.detectChanges();
   });
 
@@ -42,7 +42,30 @@ describe('WordFrequencyAnalyzerComponent', () => {
       { word: 'the', frequency: 2 },
       { word: 'lake', frequency: 1 },
       { word: 'over', frequency: 1 }];
-    let actual = component.calculateMostFrequentNWords(component.text, component.n)
+    let actual = component.calculateMostFrequentNWords(component.text, component.n);
     expect(actual).toEqual(expected);
+  });
+
+  it('calculate most frequent N words with more tests', () => {
+    let text1 = "My phone number is 06-XXXXXXXX and my e-mail address is aname@mail.com.";
+    let text2 = "A hot dog is a fastfood. It is neither made of dog meat nor an aroused dog."
+    let expected1: WordFrequency[] = [
+      { word: 'is', frequency: 2 },
+      { word: 'my', frequency: 2 },
+      { word: 'address', frequency: 1 },
+      { word: 'anamemailcom', frequency: 1 },
+      { word: 'and', frequency: 1 },
+      { word: 'email', frequency: 1}];
+    let expected2: WordFrequency[] = [
+      { word: 'dog', frequency: 3 },
+      { word: 'a', frequency: 2 },
+      { word: 'is', frequency: 2 },
+      { word: 'an', frequency: 1 },
+      { word: 'aroused', frequency: 1}
+    ];
+    let actual1 = component.calculateMostFrequentNWords(text1, expected1.length);
+    let actual2 = component.calculateMostFrequentNWords(text2, expected2.length);
+    expect(actual1).toEqual(expected1);
+    expect(actual2).toEqual(expected2);
   });
 });

--- a/src/app/word-frequency-analyzer/word-frequency-analyzer.component.spec.ts
+++ b/src/app/word-frequency-analyzer/word-frequency-analyzer.component.spec.ts
@@ -47,8 +47,8 @@ describe('WordFrequencyAnalyzerComponent', () => {
   });
 
   it('calculate most frequent N words with more tests', () => {
-    let text1 = "My phone number is 06-XXXXXXXX and my e-mail address is aname@mail.com.";
-    let text2 = "A hot dog is a fastfood. It is neither made of dog meat nor an aroused dog."
+    let text1 = "My phone number is 06-XXXXXXXX and my e-mail address is aname@mail.com. ";
+    let text2 = "A hot dog is a fastfood.   It is neither made of dog meat nor an aroused dog.  "
     let expected1: WordFrequency[] = [
       { word: 'is', frequency: 2 },
       { word: 'my', frequency: 2 },

--- a/src/app/word-frequency-analyzer/word-frequency-analyzer.component.ts
+++ b/src/app/word-frequency-analyzer/word-frequency-analyzer.component.ts
@@ -33,7 +33,7 @@ export class WordFrequencyAnalyzerComponent implements WordFrequencyAnalyzer, On
     let highestFrequency = 0
     for (let word of words) {
       // Count how many same word in text
-      let frequency = text.split(` ${word} `).length - 1;
+      let frequency = ` ${text} `.split(` ${word} `).length - 1;
       if (frequency > highestFrequency) {
         highestFrequency = frequency;
       }
@@ -52,7 +52,7 @@ export class WordFrequencyAnalyzerComponent implements WordFrequencyAnalyzer, On
     text = this.allowLettersAndSpacesOnly(text);
     // Convert text to lowercase
     text = text.toLowerCase();
-    return text.split(` ${word} `).length - 1;
+    return ` ${text} `.split(` ${word} `).length - 1;
   }
 
   /**

--- a/src/app/word-frequency-analyzer/word-frequency-analyzer.component.ts
+++ b/src/app/word-frequency-analyzer/word-frequency-analyzer.component.ts
@@ -65,15 +65,11 @@ export class WordFrequencyAnalyzerComponent implements WordFrequencyAnalyzer, On
     // Convert text to lowercase
     text = text.toLowerCase();
     // Regex for characters between "a" and "z" and between "A" and "Z"
-    let regex = /([a-zA-Z])+/
+    text = this.allowLettersAndSpacesOnly(text);
     // Split text into words
     let words = text.split(' ');
     let WordFrequencyArray: WordFrequency[] = [];
     for (let w of words) {
-      // Execute the regex to have only a-z and A-Z on every words
-      if (regex.test(w)) {
-        w = regex.exec(w)[0];
-      }
       if (WordFrequencyArray.some(({word}) => word == w)) {
         // Increment the frequent value
         let wordFrequency = WordFrequencyArray.find(({word}) => word == w);
@@ -86,9 +82,27 @@ export class WordFrequencyAnalyzerComponent implements WordFrequencyAnalyzer, On
     }
     // Sort by word in ascendant alphabetical order and then sort by frequency from high to low order
     WordFrequencyArray
-      .sort((a, b) => (a.word > b.word ? -1 : 1))
+      .sort((a, b) => (a.word < b.word ? -1 : 1))
       .sort((a, b) => (a.frequency > b.frequency ? -1 : 1));
     // Return only the first n of word frequency array
     return WordFrequencyArray.slice(0, n);
+  }
+
+  allowLettersAndSpacesOnly(text: string) : string {
+    // Regex for letters only
+    let regex = /([a-zA-Z])/
+    let newText = ''
+    for (let c of text) {
+      if (c === ' ') {
+        // Prevent double or more spaces to each
+        newText = newText.trim();
+        newText += c;
+      } else if (regex.test(c)) {
+        // Add allowed character
+        newText += c
+      }
+    }
+    // Remove spaces at the begin and the end of text and then return
+    return newText.trim();
   }
 }

--- a/src/app/word-frequency-analyzer/word-frequency-analyzer.component.ts
+++ b/src/app/word-frequency-analyzer/word-frequency-analyzer.component.ts
@@ -24,19 +24,21 @@ export class WordFrequencyAnalyzerComponent implements WordFrequencyAnalyzer, On
    * @param text
    */
   calculateHighestFrequency(text: string): number {
-      // Convert text to lowercase
-      text = text.toLowerCase();
-      // Split text into words
-      let words = text.split(' ');
-      let highestFrequency = 0
-      for (let word of words) {
-        // Count how many same word in text
-        let frequency = text.split(word).length - 1;
-        if (frequency > highestFrequency) {
-          highestFrequency = frequency;
-        }
+    // Allow letters and spaces only
+    text = this.allowLettersAndSpacesOnly(text);
+    // Convert text to lowercase
+    text = text.toLowerCase();
+    // Split text into words
+    let words = text.split(' ');
+    let highestFrequency = 0
+    for (let word of words) {
+      // Count how many same word in text
+      let frequency = text.split(` ${word} `).length - 1;
+      if (frequency > highestFrequency) {
+        highestFrequency = frequency;
       }
-      return highestFrequency;
+    }
+    return highestFrequency;
   }
 
   /**
@@ -46,9 +48,11 @@ export class WordFrequencyAnalyzerComponent implements WordFrequencyAnalyzer, On
    * @param word
    */
   calculateFrequencyForWord(text: string, word: string): number {
+    // Allow letters and spaces only
+    text = this.allowLettersAndSpacesOnly(text);
     // Convert text to lowercase
     text = text.toLowerCase();
-    return text.split(word).length - 1;
+    return text.split(` ${word} `).length - 1;
   }
 
   /**


### PR DESCRIPTION
I tested the word frequency analyzer further. I found bugs:
- Highest frequency doesn't count whole words, but count a sequence of characters, in the text. For example: it counts "the" in the text "the their them" as 3 times.
- Frequency for words has the same problem as the highest frequency.
- Most frequency n words still allows sequences of the mix of letters, special characters and numbers. So the regex is not properly working.

Now they are all fixed.